### PR TITLE
[FIX] Removing config readonly volume

### DIFF
--- a/dev-hosted.yml
+++ b/dev-hosted.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       # Host paths (odoo src code & .vscode conf)
       - ./src/odoo:/${ODOO_BASEPATH}
-      - ./config:/etc/odoo:ro
+      - ./config:/etc/odoo
       - ./.devcontainer/.vscode:/etc/.vscode
     environment:
       - LOG_LEVEL=debug


### PR DESCRIPTION
Read only option on config volume avoid to write the configuration file in the initial run of odoo container