### PR TITLE
Update the initial image from python 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-buster
+FROM python:3.7-slim-buster
 
 USER root
 


### PR DESCRIPTION
3.7-buster to 3.7-slim-buster to optimize the size of the image 
#36 
![pull request dockerdoo dockerfile](https://user-images.githubusercontent.com/3017653/67795751-831b0780-fa5d-11e9-95ed-533c3ece1a17.png)
