### PR TITLE
[FIX] entrypoint: Put modules to test as an single parameter

### DIFF
--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -91,7 +91,7 @@ case "$1" in
             if [ -z "$EXTRA_MODULES" ]; then
                 EXTRA_MODULES=$(python3 -c "from getaddons import get_modules; print(','.join(get_modules('${ODOO_EXTRA_ADDONS}', depth=3)))")
             fi
-            exec odoo "$@" "--test-enable" "--stop-after-init" "-i ${EXTRA_MODULES}" "${DB_ARGS[@]}"
+            exec odoo "$@" "--test-enable" "--stop-after-init" "-i" "${EXTRA_MODULES}" "${DB_ARGS[@]}"
         else
             exec odoo "$@" "${DB_ARGS[@]}"
         fi


### PR DESCRIPTION
The old behavior caused some modules to be read incorrectly because of spaces between -i & the modules