### PR TITLE
[FIX] docker-compose:  Use correct volumes

### DIFF
--- a/dev-hosted.yml
+++ b/dev-hosted.yml
@@ -18,9 +18,10 @@ services:
     #  context: .
     #  dockerfile: Dockerfile
     volumes:
-      # Host paths (odoo src code & .vscode conf)
-      - ./config/odoo.conf:/etc/odoo/odoo.conf:cached
+      # Host paths (odoo modules, src code & conf)
+      - ./custom:${ODOO_EXTRA_ADDONS}:delegated
       - ./src/odoo:/${ODOO_BASEPATH}:cached
+      - ./config/odoo.conf:/etc/odoo/odoo.conf:cached
     environment:
       - LOG_LEVEL=debug
       - WITHOUT_DEMO=False

--- a/dev-standalone.yml
+++ b/dev-standalone.yml
@@ -1,5 +1,8 @@
 version: "3.7"
 
+volumes:
+  odoo-modules:
+
 services:
   wdb:
     image: kozea/wdb:3.3.0
@@ -17,8 +20,8 @@ services:
     #  context: .
     #  dockerfile: Dockerfile
     volumes:
-      # Host paths (.vscode configuration)
-      - ~/.ssh/:/opt/odoo/.ssh/:cached
+      # Named volumes (third party modules)
+      - odoo-modules:${ODOO_EXTRA_ADDONS}
     environment:
       - LOG_LEVEL=debug
       - WITHOUT_DEMO=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
     ports: ["8069:8069", "8072:8072"]
 
     volumes:
-      # Host paths (addons & conf)
-      - ./custom:${ODOO_EXTRA_ADDONS}:delegated
+      # Host paths (.ssh configuration)
+      - ~/.ssh/:/opt/odoo/.ssh/:cached
       # Named volumes
       - odoo-data:${ODOO_DATA_DIR}
       - odoo-testlogs:${ODOO_LOGS_DIR}


### PR DESCRIPTION
Standalone needs a named volume to keep data saved even if the container is deleted.

Hosted is the only one needing to map modules from the computer, standalone uses modules inside the container.

SSH keys are mapped for both implementations.

This also allows a faster execution for standalone, which is the recommended approach from now on.