### PR TITLE
backport 14.0 - fix(docker): chown missing path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -270,7 +270,7 @@ ENV ODOO_CMD ${ODOO_BASEPATH}/odoo-bin
 RUN mkdir -p ${ODOO_DATA_DIR} ${ODOO_LOGS_DIR} ${ODOO_EXTRA_ADDONS} /etc/odoo/
 
 # Own folders    //-- docker-compose creates named volumes owned by root:root. Issue: https://github.com/docker/compose/issues/3270
-RUN chown -R ${ODOO_USER}:${ODOO_USER} ${ODOO_DATA_DIR} ${ODOO_LOGS_DIR} /etc/odoo
+RUN chown -R ${ODOO_USER}:${ODOO_USER} ${ODOO_DATA_DIR} ${ODOO_LOGS_DIR} ${ODOO_EXTRA_ADDONS} ${ODOO_BASEPATH} /etc/odoo
 
 VOLUME ["${ODOO_DATA_DIR}", "${ODOO_LOGS_DIR}", "${ODOO_EXTRA_ADDONS}"]
 


### PR DESCRIPTION
backporting a fix made on v14 to v12

29aba2badb4885f83e8b99933c9f387b18b489c0

