### PR TITLE
Update repo after add postgresql repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get -qq update \
     && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
     && gpgconf --kill all \
     && rm -rf "$GNUPGHOME" \
+    && apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends postgresql-client libpq-dev \
     && rm -f /etc/apt/sources.list.d/pgdg.list \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
No se instala la ultima version de postgresql-client.

Comportamiento actual antes de PR:
- La version de "postgresql-client" que se instala es la version que se encuenta en los repositorios de la imagen base.

Comportamiento despues del PR:
- La version de "postgresql-client" que se instala es la version que viene de los repositorios de PostgreSQL.