### PR TITLE
[17.0] fix(dockerfile): wrong download URL for amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -qq update \
     if [ "$(uname -m)" = "aarch64" ]; then \
         curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_arm64.deb \
     ; else \
-        curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOX_VERSION}/wkhtmltox_${WKHTMLTOX_VERSION}-1.buster_amd64.deb \
+        curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/packaging/releases/download/${WKHTMLTOX_VERSION}-1/wkhtmltox_${WKHTMLTOX_VERSION}-1.buster_amd64.deb \
         && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha1sum -c - \
     ; fi \
     && apt-get install -y --no-install-recommends ./wkhtmltox.deb \


### PR DESCRIPTION
Previous URL currently doesn't work