### PR TITLE
fix(Dockerfile): phonenumbers python package required due to account_peppol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,6 +145,7 @@ RUN pip3 install --prefix=/usr/local --no-cache-dir --upgrade --requirement http
     python-json-logger \
     wdb \
     redis \
+    phonenumbers \
     && apt-get autopurge -yqq \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
Currently for both `18.0` and `19.0` versions, when trying to install something that finally requires `account_peppol` (like e.g. `Accounting` app):

<img width="1056" height="110" alt="imagen" src="https://github.com/user-attachments/assets/67590993-c41f-447f-ba29-17e08f3c4425" />

This is solved strictly adding `phonenumbers` pip installation at `Dockerfile`.

cc @gustavovalverde 